### PR TITLE
Add Vercel CLI installation step in CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "Install Vercel CLI"
+          command: npm install -g vercel
+      - run:
           name: "Deploy to Vercel"
           command: |
             DEPLOY_URL=$(vercel --token $VERCEL_TOKEN --prod --scope << parameters.vercel_scope >>)


### PR DESCRIPTION
- Introduce a new step in the CircleCI config to install the Vercel CLI globally before deployment
- Ensure the deployment process to Vercel is streamlined with the necessary tools